### PR TITLE
feat(local-install): Add `npmEnv` option to LocalInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,14 @@ the "dependant" directory located next to the current working directory.
 Construct the `LocalInstall` by using an object. The properties of this object are the relative package locations to install into. The array values are the packages to be installed. Use the `install()` method to install, returns a promise.
 
 If you want the progress reporting like the CLI has: use `progress(localInstaller)`; 
+
+##### Passing npm env variables
+
+In some cases it might be useful to pass some custom env variables object to npm. For example when you want npm to rebuild native node modules against Electron headers. You can do it by passing `options` to `LocalInstaller`'s constructor.
+
+```javascript
+const localInstaller = new LocalInstaller(
+   { '.': ['../sibling'] },
+   { npmEnv: { envVar: 'envValue' } }
+);
+``` 

--- a/test/unit/LocalInstallerSpec.ts
+++ b/test/unit/LocalInstallerSpec.ts
@@ -86,6 +86,21 @@ describe('LocalInstaller install', () => {
         });
     });
 
+    describe('with npmEnv', () => {
+        const npmEnv = { test: 'test', dummy: 'dummy' };
+        beforeEach(() => {
+            sut = new LocalInstaller({'/a': ['b']}, { npmEnv });
+            stubPackageJson({'/a': 'a', 'b': 'b'});
+            execStub.resolves(['stdout', 'stderr']);
+            unlinkStub.resolves();
+        });
+
+        it('should call npm with correct env vars', async () => {
+            await sut.install();
+            expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a') });
+        });
+    });
+
     describe('when readFile errors', () => {
         it('should propagate the error', () => {
             readFileStub.rejects(new Error('file error'));


### PR DESCRIPTION
Hello,

I have a plan to use your package in `meteor-desktop` but I've faced a problem when installing local packages that have native node modules. The compilation goes against current node and what I need is to compile them against the electron version. For that I need to pass additional env vars to npm. I have made this small change to be able to do that.
I am a total newbie in typescript so I hope its typescriptish enough 🙂
Let me know if that can go into your next release.