### PR TITLE
Increase `maxBuffer` to 10MB (1024*1024*10)

### DIFF
--- a/src/LocalInstaller.ts
+++ b/src/LocalInstaller.ts
@@ -23,6 +23,7 @@ export interface ListByPackage {
     [key: string]: string[];
 }
 
+const TEN_MEGA_BYTE = 1024 * 1024 * 10;
 export class LocalInstaller extends EventEmitter {
 
     private sourcesByTarget: ListByPackage;
@@ -73,7 +74,7 @@ export class LocalInstaller extends EventEmitter {
         const toInstall = target.sources.map(source => resolvePackFile(source.packageJson)).join(' ');
         const options: ExecOptions = {
             cwd: target.directory,
-            maxBuffer: 1024 * 1024 * 10
+            maxBuffer: TEN_MEGA_BYTE
         };
         if (this.options.npmEnv) {
             options.env = this.options.npmEnv;
@@ -117,7 +118,7 @@ export class LocalInstaller extends EventEmitter {
     private packOne(directory: string): Promise<void> {
         return exec(`npm pack ${directory}`, {
             cwd: os.tmpdir(),
-            maxBuffer: 1024 * 1024 * 10
+            maxBuffer: TEN_MEGA_BYTE
         }).then(() => void this.emit('packed', directory));
     }
 

--- a/src/LocalInstaller.ts
+++ b/src/LocalInstaller.ts
@@ -71,7 +71,10 @@ export class LocalInstaller extends EventEmitter {
 
     private installOne(target: InstallTarget): Promise<void> {
         const toInstall = target.sources.map(source => resolvePackFile(source.packageJson)).join(' ');
-        const options: ExecOptions = { cwd: target.directory };
+        const options: ExecOptions = {
+            cwd: target.directory,
+            maxBuffer: 1024 * 1024 * 10
+        };
         if (this.options.npmEnv) {
             options.env = this.options.npmEnv;
         }
@@ -112,8 +115,10 @@ export class LocalInstaller extends EventEmitter {
     }
 
     private packOne(directory: string): Promise<void> {
-        return exec(`npm pack ${directory}`, { cwd: os.tmpdir() })
-            .then(() => void this.emit('packed', directory));
+        return exec(`npm pack ${directory}`, {
+            cwd: os.tmpdir(),
+            maxBuffer: 1024 * 1024 * 10
+        }).then(() => void this.emit('packed', directory));
     }
 
     private removeAllPackedTarballs(allSources: string[], packages: PackageByDirectory): Promise<void[]> {

--- a/test/unit/LocalInstallerSpec.ts
+++ b/test/unit/LocalInstallerSpec.ts
@@ -33,17 +33,19 @@ describe('LocalInstaller install', () => {
 
         it('should pack correct packages', async () => {
             await sut.install();
-            expect(execStub).calledWith(`npm pack ${resolve('b')}`, { cwd: os.tmpdir() });
-            expect(execStub).calledWith(`npm pack ${resolve('c')}`, { cwd: os.tmpdir() });
-            expect(execStub).calledWith(`npm pack ${resolve('/e')}`, { cwd: os.tmpdir() });
+            const maxBuffer = 1024 * 1024 * 10;
+            expect(execStub).calledWith(`npm pack ${resolve('b')}`, { cwd: os.tmpdir(), maxBuffer });
+            expect(execStub).calledWith(`npm pack ${resolve('c')}`, { cwd: os.tmpdir(), maxBuffer });
+            expect(execStub).calledWith(`npm pack ${resolve('/e')}`, { cwd: os.tmpdir(), maxBuffer });
         });
 
         it('should install correct packages', async () => {
             await sut.install();
+            const maxBuffer = 1024 * 1024 * 10;
             expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')} ${tmp('c-0.0.2.tgz')}`,
-                { cwd: resolve('/a') });
+                { cwd: resolve('/a'), maxBuffer });
             expect(execStub).calledWith(`npm i --no-save ${tmp('e-0.0.4.tgz')}`,
-                { cwd: resolve('d') });
+                { cwd: resolve('d'), maxBuffer });
         });
 
         it('should emit all events', async () => {
@@ -97,7 +99,7 @@ describe('LocalInstaller install', () => {
 
         it('should call npm with correct env vars', async () => {
             await sut.install();
-            expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a') });
+            expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a'), maxBuffer: 1024 * 1024 * 10 });
         });
     });
 

--- a/test/unit/LocalInstallerSpec.ts
+++ b/test/unit/LocalInstallerSpec.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { resolve } from 'path';
 import * as sinon from 'sinon';
 import { LocalInstaller } from './../../src/LocalInstaller';
-
+const TEN_MEGA_BYTE = 1024 * 1024 * 10;
 describe('LocalInstaller install', () => {
     let sut: LocalInstaller;
     let sandbox: sinon.SinonSandbox;
@@ -33,19 +33,17 @@ describe('LocalInstaller install', () => {
 
         it('should pack correct packages', async () => {
             await sut.install();
-            const maxBuffer = 1024 * 1024 * 10;
-            expect(execStub).calledWith(`npm pack ${resolve('b')}`, { cwd: os.tmpdir(), maxBuffer });
-            expect(execStub).calledWith(`npm pack ${resolve('c')}`, { cwd: os.tmpdir(), maxBuffer });
-            expect(execStub).calledWith(`npm pack ${resolve('/e')}`, { cwd: os.tmpdir(), maxBuffer });
+            expect(execStub).calledWith(`npm pack ${resolve('b')}`, { cwd: os.tmpdir(), maxBuffer: TEN_MEGA_BYTE });
+            expect(execStub).calledWith(`npm pack ${resolve('c')}`, { cwd: os.tmpdir(), maxBuffer: TEN_MEGA_BYTE });
+            expect(execStub).calledWith(`npm pack ${resolve('/e')}`, { cwd: os.tmpdir(), maxBuffer: TEN_MEGA_BYTE });
         });
 
         it('should install correct packages', async () => {
             await sut.install();
-            const maxBuffer = 1024 * 1024 * 10;
             expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')} ${tmp('c-0.0.2.tgz')}`,
-                { cwd: resolve('/a'), maxBuffer });
+                { cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE });
             expect(execStub).calledWith(`npm i --no-save ${tmp('e-0.0.4.tgz')}`,
-                { cwd: resolve('d'), maxBuffer });
+                { cwd: resolve('d'), maxBuffer: TEN_MEGA_BYTE });
         });
 
         it('should emit all events', async () => {
@@ -99,7 +97,7 @@ describe('LocalInstaller install', () => {
 
         it('should call npm with correct env vars', async () => {
             await sut.install();
-            expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a'), maxBuffer: 1024 * 1024 * 10 });
+            expect(execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE });
         });
     });
 


### PR DESCRIPTION
fix #8 

In my local, following tests is failed(master branch too)

- mac
- npm 6.1.0
- node.js 10.0.0

```
  36 passing (12s)
  1 failing

  1) install-local cli given 3 packages
       should install 2 packages and update the package.json if -S is provided:

      AssertionError: expected { Object (name, version, ...) } to deeply equal { Object (localDependencies, name, ...) }
      + expected - actual

       {
         "localDependencies": {
      -    "three": "../../../../../../../../var/folders/3h/ksxf_vgd08z_jy__g662s1rm0000gn/T/local-installer-it/three"
      -    "two": "../../../../../../../../var/folders/3h/ksxf_vgd08z_jy__g662s1rm0000gn/T/local-installer-it/two"
      +    "three": "../three"
      +    "two": "../two"
         }
         "name": "one"
         "version": "0.0.0"
       }

```