### PR TITLE
Only install production dependencies

### DIFF
--- a/src/LocalInstaller.ts
+++ b/src/LocalInstaller.ts
@@ -96,7 +96,7 @@ export class LocalInstaller extends EventEmitter {
         if (this.options.npmEnv) {
             options.env = this.options.npmEnv;
         }
-        return exec(`npm i --no-save ${toInstall}`, options).then(([stdout, stderr]) =>
+        return exec(`npm i --production --no-save ${toInstall}`, options).then(([stdout, stderr]) =>
             void this.emit('installed', target.packageJson.name, stdout.toString(), stderr.toString()));
     }
 

--- a/test/unit/LocalInstallerSpec.ts
+++ b/test/unit/LocalInstallerSpec.ts
@@ -53,9 +53,9 @@ describe('LocalInstaller install', () => {
 
         it('should install correct packages', async () => {
             await sut.install();
-            expect(helper.execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')} ${tmp('c-0.0.2.tgz')}`,
+            expect(helper.execStub).calledWith(`npm i --production --no-save ${tmp('b-0.0.1.tgz')} ${tmp('c-0.0.2.tgz')}`,
                 { cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE });
-            expect(helper.execStub).calledWith(`npm i --no-save ${tmp('e-0.0.4.tgz')}`,
+            expect(helper.execStub).calledWith(`npm i --production --no-save ${tmp('e-0.0.4.tgz')}`,
                 { cwd: resolve('d'), maxBuffer: TEN_MEGA_BYTE });
         });
 
@@ -101,7 +101,7 @@ describe('LocalInstaller install', () => {
 
         it('should install scoped packages', async () => {
             await sut.install();
-            expect(helper.execStub).calledWith(`npm i --no-save ${tmp('s-b-0.0.1.tgz')}`);
+            expect(helper.execStub).calledWith(`npm i --production --no-save ${tmp('s-b-0.0.1.tgz')}`);
         });
     });
 
@@ -116,7 +116,8 @@ describe('LocalInstaller install', () => {
 
         it('should call npm with correct env vars', async () => {
             await sut.install();
-            expect(helper.execStub).calledWith(`npm i --no-save ${tmp('b-0.0.1.tgz')}`, { env: npmEnv, cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE });
+            expect(helper.execStub).calledWith(`npm i --production --no-save ${tmp('b-0.0.1.tgz')}`,
+                    { env: npmEnv, cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE });
         });
     });
 


### PR DESCRIPTION
Otherwise, installing the packed dependency will also install that
dependency's non-production dependencies.