### PR TITLE
feat(install): ignore other dependencies

### DIFF
--- a/src/LocalInstaller.ts
+++ b/src/LocalInstaller.ts
@@ -97,7 +97,7 @@ export class LocalInstaller extends EventEmitter {
     };
     const { stdout, stderr } = await exec(
       'npm',
-      ['i', '--no-save', ...toInstall],
+      ['i', '--no-save', '--no-package-lock', ...toInstall],
       options,
     );
     this.emit(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import { execute, Options } from './index';
 
-export function cli(argv: string[]): Promise<void> {
+export async function cli(argv: string[]): Promise<void> {
   const l = console.log;
   const options = new Options(argv);
   if (options.help) {
@@ -44,8 +44,8 @@ export function cli(argv: string[]): Promise<void> {
     l(
       '   install the packages of 2 sibling directories into the current directory and save them to "localDependencies" in your package.json file.',
     );
-    return Promise.resolve();
   } else {
-    return options.validate().then(() => execute(options));
+    await options.validate();
+    await execute(options);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export interface PackageJson {
   name: string;
   version: string;
   localDependencies?: Dependencies;
+  devDependencies?: Dependencies;
+  dependencies?: Dependencies;
 }
 
 export interface Dependencies {

--- a/test/unit/LocalInstallerSpec.ts
+++ b/test/unit/LocalInstallerSpec.ts
@@ -83,12 +83,18 @@ describe('LocalInstaller install', () => {
       await sut.install();
       expect(helper.execStub).calledWith(
         'npm',
-        ['i', '--no-save', tmp('b-0.0.1.tgz'), tmp('c-0.0.2.tgz')],
+        [
+          'i',
+          '--no-save',
+          '--no-package-lock',
+          tmp('b-0.0.1.tgz'),
+          tmp('c-0.0.2.tgz'),
+        ],
         { cwd: resolve('/a'), env: undefined, maxBuffer: TEN_MEGA_BYTE },
       );
       expect(helper.execStub).calledWith(
         'npm',
-        ['i', '--no-save', tmp('e-0.0.4.tgz')],
+        ['i', '--no-save', '--no-package-lock', tmp('e-0.0.4.tgz')],
         { cwd: resolve('d'), env: undefined, maxBuffer: TEN_MEGA_BYTE },
       );
     });
@@ -140,6 +146,7 @@ describe('LocalInstaller install', () => {
       expect(helper.execStub).calledWith('npm', [
         'i',
         '--no-save',
+        '--no-package-lock',
         tmp('s-b-0.0.1.tgz'),
       ]);
     });
@@ -160,7 +167,7 @@ describe('LocalInstaller install', () => {
       await sut.install();
       expect(helper.execStub).calledWith(
         'npm',
-        ['i', '--no-save', tmp('b-0.0.1.tgz')],
+        ['i', '--no-save', '--no-package-lock', tmp('b-0.0.1.tgz')],
         { env: npmEnv, cwd: resolve('/a'), maxBuffer: TEN_MEGA_BYTE },
       );
     });


### PR DESCRIPTION
Ignore other `dependencies` and `devDependencies` when running `npm install`. Since the era of package-lock files,`install-local ../foo` would both install `../foo` AND the packages listed in package-lock.json. This behavior was an unfortunate side effect.

BREAKING CHANGE: Other dependencies will no longer be installed. If you want the old behaviour, be sure to run `npm install` before you run `install-local`.

Fixes #23